### PR TITLE
Create a Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.nstarlike</groupId>
+    <artifactId>javalogger</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>JavaLogger</name>
+    <description>Library for logging</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+</project>


### PR DESCRIPTION
- Packaging type: jar
This project is for a library. This program will be used in other programs. So jar is proper.
- JDK version: 17
The 2024-03 version of Eclipse embeds the JRE of which version is 17. So I set the property for the Maven compiler as 17. 